### PR TITLE
ci: fixes CodeCov's unusable report

### DIFF
--- a/.github/workflows/code-coverage-reporter.yaml
+++ b/.github/workflows/code-coverage-reporter.yaml
@@ -28,6 +28,7 @@ jobs:
 
     needs: build
     steps:
+      - uses: actions/checkout@v3
       - name: Download coverage report
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
# Fixed

- Properly sends coverage report to CodeCov