### PR TITLE
ci: add Coveralls integration

### DIFF
--- a/.github/workflows/code-coverage-reporter.yaml
+++ b/.github/workflows/code-coverage-reporter.yaml
@@ -48,5 +48,5 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage-result
-      - name: Coveralls
+      - name: Upload coverage reports to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/code-coverage-reporter.yaml
+++ b/.github/workflows/code-coverage-reporter.yaml
@@ -37,3 +37,16 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  coveralls-reporter:
+    runs-on: ubuntu-latest
+    name: coveralls-reporter
+
+    needs: build
+    steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-result
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ tools and libraries in Python
 - [CodeCov](https://app.codecov.io/gh/jonasue20/test-cov-python)
   [![codecov](https://codecov.io/gh/jonasue20/test-cov-python/branch/main/graph/badge.svg?token=EQZNSQMPZ0)](https://codecov.io/gh/jonasue20/test-cov-python)
 
+- [Coveralls](https://coveralls.io/github/jonasue20/test-cov-python)
+  [![Coverage Status](https://coveralls.io/repos/github/jonasue20/test-cov-python/badge.svg?branch=main)](https://coveralls.io/github/jonasue20/test-cov-python?branch=main)
+
 ## Setup instructions
 
 The following tools are required:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tools and libraries in Python
   [![codecov](https://codecov.io/gh/jonasue20/test-cov-python/branch/main/graph/badge.svg?token=EQZNSQMPZ0)](https://codecov.io/gh/jonasue20/test-cov-python)
 
 - [Coveralls](https://coveralls.io/github/jonasue20/test-cov-python)
-  [![Coverage Status](https://coveralls.io/repos/github/jonasue20/test-cov-python/badge.svg?branch=main)](https://coveralls.io/github/jonasue20/test-cov-python?branch=main)
+  [![Coverage Status](https://coveralls.io/repos/github/jonasue20/test-cov-python/badge.svg)](https://coveralls.io/github/jonasue20/test-cov-python)
 
 ## Setup instructions
 


### PR DESCRIPTION
# Added

- Coveralls integration on workflow and readme

**Note:** Same as #4, but trying to get Coveralls to comment this time